### PR TITLE
Update gh-deploy.yml

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -23,3 +23,6 @@ jobs:
         with:
           target_branch: gh-pages
           build_dir: build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    


### PR DESCRIPTION
Added the `GITHUB_TOKEN` env variable to the github action which I didn't add earlier 'cuz I thought it was only required if you had two factor authentication enabled (i don't have).

Generate a new Github Access Token and it as a repo secret named as `GITHUB_TOKEN`.

I really wish it works this time.